### PR TITLE
Fix flickering seen in chromium-browsers

### DIFF
--- a/Public/css/common.css
+++ b/Public/css/common.css
@@ -3,6 +3,11 @@
   height: 2rem;
 }
 
+/* Overide box-sizing to avoid flicker seen in chromium-browsers */
+*, *::before, *::after {
+  box-sizing: content-box;
+}
+
 #editor-container {
   position: relative;
   height: 100%;


### PR DESCRIPTION
When the URL https://swift-ast-explorer.com/ is opened in Chrome or any other Chromium-based browsers - Edge, Vivaldi - there is a lot of flicker on the Structure, Syntax, Statistics panels.  Turns out setting the `box-sizing` to `content-box` removes this flicker.  Also verified this on Safari and Firefox, the functionality is not affected by this change.