### PR TITLE
Exclude Swift from Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,9 @@
     "config:recommended"
   ],
   "enabledManagers": [
-    "npm",
-    "github-actions"
+    "dockerfile",
+    "github-actions",
+    "npm"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Swift dependencies are regularly updated by the "Update Swift Package" workflow.
